### PR TITLE
as of ray-aabb@3.0.0 there is a way to compute the intersection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note that the `direction` vector should be normalized.
 
 ## See Also
 
-* [ray-aabb](http://github.com/tmpvar/ray-aabb) — faster, but doesn't provide the point of intersection.
+* [ray-aabb](http://github.com/tmpvar/ray-aabb)
 * [ray-sphere-intersection](http://github.com/mattdesl/ray-sphere-intersection)
 * [ray-plane-intersection](http://github.com/mattdesl/ray-plane-intersection)
 * [ray-triangle-intersection](http://github.com/substack/ray-triangle-intersection)


### PR DESCRIPTION
by passing a second (truthy) arg to `Ray#intersects` it will return `false` or a number which can be used to find the intersection.
